### PR TITLE
Create workflows to ingest Hydrofabric

### DIFF
--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,3 @@
+# Argo Workflow Archive
+
+This directory contains a collection of `Workflow` definitions for Argo to do tasks that we may want to repeat.  As we learn Argo better, we might be able to make better use of these resources for more complex tasks.

--- a/workflows/ingest-hydrofabric.yaml
+++ b/workflows/ingest-hydrofabric.yaml
@@ -1,0 +1,50 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: ingest-gpkg-
+spec:
+  entrypoint: ogr2ogr-ingest
+  arguments:
+    parameters:
+    - name: gpkg-path
+      value: "/vsis3/nextgen-hydrofabric/v1.2/conus.gpkg"
+    - name: target-db
+      value: "hydrofabric"
+  templates:
+  - name: ogr2ogr-ingest
+    steps:
+    - - name: ogr2ogr-ingest
+        template: ogr2ogr-ingest-to-postgis
+        arguments:
+          parameters:
+          - name: src-path
+            value: "{{workflow.parameters.gpkg-path}}"
+          - name: target-db
+            value: "{{workflow.parameters.target-db}}"
+
+  - name: ogr2ogr-ingest-to-postgis
+    inputs:
+      parameters:
+      - name: src-path
+      - name: target-db
+    container:
+      image: osgeo/gdal
+      command: [sh,-c]
+      args:
+      - 'ogr2ogr -f PostgreSQL "PG:dbname={{inputs.parameters.target-db}} host=$PGHOST user=$PGUSER password=$PGPASSWORD" "{{inputs.parameters.src-path}}"'
+      env:
+        - name: PGHOST
+          valueFrom:
+            secretKeyRef:
+              name: rds-credentials
+              key: host
+        - name: PGUSER
+          valueFrom:
+            secretKeyRef:
+              name: rds-credentials
+              key: username
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: rds-credentials
+              key: password

--- a/workflows/init-postgis-db.yaml
+++ b/workflows/init-postgis-db.yaml
@@ -1,0 +1,90 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: init-postgis-db-
+spec:
+  entrypoint: postgis-db-init
+  arguments:
+    parameters:
+    - name: target-database-name
+  templates:
+  - name: postgis-db-init
+    steps:
+    - - name: ensure-db
+        template: ensure-db-exists
+        arguments:
+          parameters:
+          - name: target-db-name
+            value: "{{workflow.parameters.target-database-name}}"
+
+  - name: ensure-db-exists
+    inputs:
+      parameters:
+      - name: target-db-name
+    script:
+      image: cheewai/py3-psycopg2
+      command: [python]
+      env:
+        - name: PGHOST
+          valueFrom:
+            secretKeyRef:
+              name: rds-credentials
+              key: host
+        - name: PGUSER
+          valueFrom:
+            secretKeyRef:
+              name: rds-credentials
+              key: username
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: rds-credentials
+              key: password
+      source: |
+        import os
+        import psycopg2 as pg
+        from psycopg2 import sql
+        import sys
+
+        pghost = os.environ['PGHOST']
+        pguser = os.environ['PGUSER']
+        pgpass = os.environ['PGPASSWORD']
+
+        try:
+          with pg.connect(
+            dbname = 'postgres',
+            user = pguser,
+            password = pgpass,
+            host = pghost,
+            port = 5432
+          ) as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+              cur.execute(
+                sql.SQL("SELECT 1 FROM pg_catalog.pg_database WHERE datname = '{{inputs.parameters.target-db-name}}'")
+              )
+              if cur.fetchone():
+                print(f"Database {{inputs.parameters.target-db-name}} exists, not creating DB")
+              else:
+                print(f"Database {{inputs.parameters.target-db-name}} not found, creating...")
+                cur.execute(
+                  sql.SQL("CREATE DATABASE {{inputs.parameters.target-db-name}}")
+                )
+
+          with pg.connect(
+            dbname = '{{inputs.parameters.target-db-name}}',
+            user = pguser,
+            password = pgpass,
+            host = pghost,
+            port = 5432
+          ) as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+              cur.execute(sql.SQL("CREATE EXTENSION IF NOT EXISTS postgis;"))
+
+        except Exception as e:
+          print(f"Failed: {e}")
+          sys.exit(1)
+
+        print("Success")
+        sys.exit(0)


### PR DESCRIPTION
## Overview

Now that Argo Workflows has been properly set up on the cluster, we can start using it for one-off tasks.  We can do ad hoc workflows to use cluster resources more easily, but we can also track the steps that were taken to make changes that persist in the cluster that we may one day need to replicate.  This PR creates a `workflows` directory in this repo where we can store these mementos.  As our sophistication increases with Argo, we should be able to create useful workflow templates that can be reused in modular workflows.

This initial contribution makes the specific contributions of workflows to create new, PostGIS-enabled databases, and to load a GPKG into a database.

Closes #109 

### Checklist

- [x] ~Ran `nbautoexport export .` in `/opt/src/notebooks` and committed the generated scripts. This is to make reviewing notebooks easier. (Note the export will happen automatically after saving notebooks from the Jupyter web app.)~
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

NA

## Testing Instructions

- Log into `argo.noaa.azavea.com` using Azavea credentials
  - (You may have to accept the self-signed certificate if I haven't issued a formal cert in time)
- Create a new workflow in the `argo` workspace
- Paste the contents of the workflow into the edit window
- Adjust the parameter values in the Parameters tab
- Run the workflow
- Delete the workflow when you're done with it
  - This cleans up the pods from the cluster, which is needed to not clog up the works and force the creation of new infrastructure that isn't needed
