### PR TITLE
Batch tasks using Dask in Argo

### DIFF
--- a/src/python-scripts/compute-base-flow.py
+++ b/src/python-scripts/compute-base-flow.py
@@ -1,5 +1,6 @@
 import logging
 
+import dask
 import dask_gateway
 import numpy as np
 import pandas as pd
@@ -8,28 +9,30 @@ import xarray as xr
 
 logger = logging.getLogger("DaskWorkflow")
 
-logger.error("Test")
-gw = dask_gateway.Gateway(auth="jupyterhub")
-logger.warn(f"Using auth of type {type(gw.auth)}")
-logger.info(f"Auth token: {gw.auth.api_token}")
+try:
+    gw = dask_gateway.Gateway(auth="jupyterhub")
+    logger.warning(f"Using auth of type {type(gw.auth)}")
 
-opts = gw.cluster_options()
-opts.worker_memory = 10
-if gw.list_clusters() == []:
-    cluster = gw.new_cluster(opts)
-    cluster.scale(16)
-else:
-    cluster = dask_gateway.GatewayCluster.from_name(gw.list_clusters()[0].name)
+    opts = gw.cluster_options()
+    opts.worker_memory = 10
+    if gw.list_clusters() == []:
+        cluster = gw.new_cluster(opts)
+        cluster.scale(16)
+    else:
+        cluster = dask_gateway.GatewayCluster.from_name(gw.list_clusters()[0].name)
 
-client = cluster.get_client()
+    client = cluster.get_client()
 
-nwm_uri = 's3://noaa-nwm-retrospective-2-1-zarr-pds/chrtout.zarr'
-ds = xr.open_zarr(nwm_uri)
-recent = ds.where(ds['time'] >= np.datetime64('2010-01-01'), drop=True)
-weekly_avg = recent.streamflow.groupby('time.week').mean().rename('mean')
-weekly_std = recent.streamflow.groupby('time.week').std().rename('std')
-base_flow = xr.merge([weekly_avg, weekly_std])
+    logger.warning(f"Client dashboard: {client.dashboard_link}")
 
-base_flow.to_zarr('s3://azavea-noaa-hydro-data-public/nwm-base-flow.zarr', mode='w')
+    with dask.config.set(**{'array.slicing.split_large_chunks': False}):
+        nwm_uri = 's3://noaa-nwm-retrospective-2-1-zarr-pds/chrtout.zarr'
+        ds = xr.open_zarr(nwm_uri)
+        recent = ds.where(ds['time'] >= np.datetime64('2010-01-01'), drop=True)
+        weekly_avg = recent.streamflow.groupby('time.week').mean().rename('mean')
+        weekly_std = recent.streamflow.groupby('time.week').std().rename('std')
+        base_flow = xr.merge([weekly_avg, weekly_std])
 
-gw.stop_cluster(client.cluster.name)
+        base_flow.to_zarr('s3://azavea-noaa-hydro-data-public/nwm-base-flow.zarr', mode='w')
+finally:
+    gw.stop_cluster(client.cluster.name)

--- a/src/python-scripts/compute-base-flow.py
+++ b/src/python-scripts/compute-base-flow.py
@@ -1,0 +1,27 @@
+import dask_gateway
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+
+gw = dask_gateway.Gateway()
+
+opts = gw.cluster_options()
+opts.worker_memory = 10
+if gw.list_clusters() == []:
+    cluster = gw.new_cluster(opts)
+    cluster.scale(16)
+else:
+    cluster = dask_gateway.GatewayCluster.from_name(gw.list_clusters()[0].name)
+
+client = cluster.get_client()
+
+nwm_uri = 's3://noaa-nwm-retrospective-2-1-zarr-pds/chrtout.zarr'
+recent = xr.open_zarr(nwm_uri).where(ds['time'] >= np.datetime64('2010-01-01'), drop=True)
+weekly_avg = recent.streamflow.groupby('time.week').mean().rename('mean')
+weekly_std = recent.streamflow.groupby('time.week').std().rename('std')
+base_flow = xr.merge([weekly_avg, weekly_std])
+
+base_flow.to_zarr('s3://azavea-noaa-hydro-data-public/nwm-base-flow.zarr', mode='w')
+
+gw.stop_cluster(client.cluster.name)

--- a/src/python-scripts/compute-base-flow.py
+++ b/src/python-scripts/compute-base-flow.py
@@ -14,13 +14,12 @@ logger.warning(f"Using auth of type {type(gw.auth)}")
 
 try:
     opts = gw.cluster_options()
-    opts.worker_memory = 16
-    if gw.list_clusters() == []:
-        cluster = gw.new_cluster(opts)
-        cluster.scale(32)
-    else:
-        cluster = dask_gateway.GatewayCluster.from_name(gw.list_clusters()[0].name)
-
+    opts.worker_memory = int(os.environ['DASK_OPTS__WORKER_MEMORY'])
+    opts.worker_cores = int(os.environ['DASK_OPTS__WORKER_CORES'])
+    opts.scheduler_memory = int(os.environ['DASK_OPTS__SCHEDULER_MEMORY'])
+    opts.scheduler_cores = int(os.environ['DASK_OPTS__SCHEDULER_CORES'])
+    cluster = gw.new_cluster(opts)
+    cluster.scale(int(os.environ['DASK_OPTS__N_WORKERS']))
     client = cluster.get_client()
 
     logger.warning(f"Client dashboard: {client.dashboard_link}")

--- a/src/python-scripts/compute-base-flow.py
+++ b/src/python-scripts/compute-base-flow.py
@@ -1,13 +1,17 @@
+import logging
+
 import dask_gateway
 import numpy as np
 import pandas as pd
 import xarray as xr
 
 
-print("Sample text")
+logger = logging.getLogger("DaskWorkflow")
+
+logger.error("Test")
 gw = dask_gateway.Gateway(auth="jupyterhub")
-print(type(gw.auth))
-print(gw.auth.api_token)
+logger.warn(f"Using auth of type {type(gw.auth)}")
+logger.info(f"Auth token: {gw.auth.api_token}")
 
 opts = gw.cluster_options()
 opts.worker_memory = 10
@@ -20,7 +24,8 @@ else:
 client = cluster.get_client()
 
 nwm_uri = 's3://noaa-nwm-retrospective-2-1-zarr-pds/chrtout.zarr'
-recent = xr.open_zarr(nwm_uri).where(ds['time'] >= np.datetime64('2010-01-01'), drop=True)
+ds = xr.open_zarr(nwm_uri)
+recent = ds.where(ds['time'] >= np.datetime64('2010-01-01'), drop=True)
 weekly_avg = recent.streamflow.groupby('time.week').mean().rename('mean')
 weekly_std = recent.streamflow.groupby('time.week').std().rename('std')
 base_flow = xr.merge([weekly_avg, weekly_std])

--- a/src/python-scripts/compute-base-flow.py
+++ b/src/python-scripts/compute-base-flow.py
@@ -9,29 +9,33 @@ import xarray as xr
 
 logger = logging.getLogger("DaskWorkflow")
 
-gw = dask_gateway.Gateway(auth="jupyterhub")
-logger.warning(f"Using auth of type {type(gw.auth)}")
+def main():
+    gw = dask_gateway.Gateway(auth="jupyterhub")
+    logger.warning(f"Using auth of type {type(gw.auth)}")
 
-try:
-    opts = gw.cluster_options()
-    opts.worker_memory = int(os.environ['DASK_OPTS__WORKER_MEMORY'])
-    opts.worker_cores = int(os.environ['DASK_OPTS__WORKER_CORES'])
-    opts.scheduler_memory = int(os.environ['DASK_OPTS__SCHEDULER_MEMORY'])
-    opts.scheduler_cores = int(os.environ['DASK_OPTS__SCHEDULER_CORES'])
-    cluster = gw.new_cluster(opts)
-    cluster.scale(int(os.environ['DASK_OPTS__N_WORKERS']))
-    client = cluster.get_client()
+    try:
+        opts = gw.cluster_options()
+        opts.worker_memory = int(os.environ['DASK_OPTS__WORKER_MEMORY'])
+        opts.worker_cores = int(os.environ['DASK_OPTS__WORKER_CORES'])
+        opts.scheduler_memory = int(os.environ['DASK_OPTS__SCHEDULER_MEMORY'])
+        opts.scheduler_cores = int(os.environ['DASK_OPTS__SCHEDULER_CORES'])
+        cluster = gw.new_cluster(opts)
+        cluster.scale(int(os.environ['DASK_OPTS__N_WORKERS']))
+        client = cluster.get_client()
 
-    logger.warning(f"Client dashboard: {client.dashboard_link}")
+        logger.warning(f"Client dashboard: {client.dashboard_link}")
 
-    with dask.config.set(**{'array.slicing.split_large_chunks': False}):
-        nwm_uri = 's3://noaa-nwm-retrospective-2-1-zarr-pds/chrtout.zarr'
-        ds = xr.open_zarr(nwm_uri)
-        recent = ds.where(ds['time'] >= np.datetime64('2010-01-01'), drop=True)
-        weekly_avg = recent.streamflow.groupby('time.week').mean().rename('mean')
-        weekly_std = recent.streamflow.groupby('time.week').std().rename('std')
-        base_flow = xr.merge([weekly_avg, weekly_std])
+        with dask.config.set(**{'array.slicing.split_large_chunks': False}):
+            nwm_uri = 's3://noaa-nwm-retrospective-2-1-zarr-pds/chrtout.zarr'
+            ds = xr.open_zarr(nwm_uri)
+            recent = ds.where(ds['time'] >= np.datetime64('2010-01-01'), drop=True)
+            weekly_avg = recent.streamflow.groupby('time.week').mean().rename('mean')
+            weekly_std = recent.streamflow.groupby('time.week').std().rename('std')
+            base_flow = xr.merge([weekly_avg, weekly_std])
 
-        base_flow.to_zarr('s3://azavea-noaa-hydro-data-public/nwm-base-flow.zarr', mode='w')
-finally:
-    gw.stop_cluster(client.cluster.name)
+            base_flow.to_zarr('s3://azavea-noaa-hydro-data-public/nwm-base-flow.zarr', mode='w')
+    finally:
+        gw.stop_cluster(client.cluster.name)
+
+if __name__ == "__main__":
+    main()

--- a/src/python-scripts/compute-base-flow.py
+++ b/src/python-scripts/compute-base-flow.py
@@ -4,7 +4,7 @@ import pandas as pd
 import xarray as xr
 
 
-gw = dask_gateway.Gateway()
+gw = dask_gateway.Gateway(auth="jupyterhub")
 print(gw.auth)
 
 opts = gw.cluster_options()

--- a/src/python-scripts/compute-base-flow.py
+++ b/src/python-scripts/compute-base-flow.py
@@ -9,6 +9,17 @@ import xarray as xr
 
 logger = logging.getLogger("DaskWorkflow")
 
+def client_code():
+    with dask.config.set(**{'array.slicing.split_large_chunks': False}):
+        nwm_uri = 's3://noaa-nwm-retrospective-2-1-zarr-pds/chrtout.zarr'
+        ds = xr.open_zarr(nwm_uri)
+        recent = ds.where(ds['time'] >= np.datetime64('2010-01-01'), drop=True)
+        weekly_avg = recent.streamflow.groupby('time.week').mean().rename('mean')
+        weekly_std = recent.streamflow.groupby('time.week').std().rename('std')
+        base_flow = xr.merge([weekly_avg, weekly_std])
+
+        base_flow.to_zarr('s3://azavea-noaa-hydro-data-public/nwm-base-flow.zarr', mode='w')
+
 def main():
     gw = dask_gateway.Gateway(auth="jupyterhub")
     logger.warning(f"Using auth of type {type(gw.auth)}")
@@ -25,15 +36,7 @@ def main():
 
         logger.warning(f"Client dashboard: {client.dashboard_link}")
 
-        with dask.config.set(**{'array.slicing.split_large_chunks': False}):
-            nwm_uri = 's3://noaa-nwm-retrospective-2-1-zarr-pds/chrtout.zarr'
-            ds = xr.open_zarr(nwm_uri)
-            recent = ds.where(ds['time'] >= np.datetime64('2010-01-01'), drop=True)
-            weekly_avg = recent.streamflow.groupby('time.week').mean().rename('mean')
-            weekly_std = recent.streamflow.groupby('time.week').std().rename('std')
-            base_flow = xr.merge([weekly_avg, weekly_std])
-
-            base_flow.to_zarr('s3://azavea-noaa-hydro-data-public/nwm-base-flow.zarr', mode='w')
+        client_code()
     finally:
         gw.stop_cluster(client.cluster.name)
 

--- a/src/python-scripts/compute-base-flow.py
+++ b/src/python-scripts/compute-base-flow.py
@@ -14,10 +14,10 @@ logger.warning(f"Using auth of type {type(gw.auth)}")
 
 try:
     opts = gw.cluster_options()
-    opts.worker_memory = 10
+    opts.worker_memory = 16
     if gw.list_clusters() == []:
         cluster = gw.new_cluster(opts)
-        cluster.scale(16)
+        cluster.scale(32)
     else:
         cluster = dask_gateway.GatewayCluster.from_name(gw.list_clusters()[0].name)
 

--- a/src/python-scripts/compute-base-flow.py
+++ b/src/python-scripts/compute-base-flow.py
@@ -9,10 +9,10 @@ import xarray as xr
 
 logger = logging.getLogger("DaskWorkflow")
 
-try:
-    gw = dask_gateway.Gateway(auth="jupyterhub")
-    logger.warning(f"Using auth of type {type(gw.auth)}")
+gw = dask_gateway.Gateway(auth="jupyterhub")
+logger.warning(f"Using auth of type {type(gw.auth)}")
 
+try:
     opts = gw.cluster_options()
     opts.worker_memory = 10
     if gw.list_clusters() == []:

--- a/src/python-scripts/compute-base-flow.py
+++ b/src/python-scripts/compute-base-flow.py
@@ -4,8 +4,10 @@ import pandas as pd
 import xarray as xr
 
 
+print("Sample text")
 gw = dask_gateway.Gateway(auth="jupyterhub")
-print(gw.auth)
+print(type(gw.auth))
+print(gw.auth.api_token)
 
 opts = gw.cluster_options()
 opts.worker_memory = 10

--- a/src/python-scripts/compute-base-flow.py
+++ b/src/python-scripts/compute-base-flow.py
@@ -4,7 +4,8 @@ import pandas as pd
 import xarray as xr
 
 
-gw = dask_gateway.Gateway(auth="jupyterhub")
+gw = dask_gateway.Gateway()
+print(gw.auth)
 
 opts = gw.cluster_options()
 opts.worker_memory = 10

--- a/src/python-scripts/compute-base-flow.py
+++ b/src/python-scripts/compute-base-flow.py
@@ -4,7 +4,7 @@ import pandas as pd
 import xarray as xr
 
 
-gw = dask_gateway.Gateway()
+gw = dask_gateway.Gateway(auth="jupyterhub")
 
 opts = gw.cluster_options()
 opts.worker_memory = 10

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -12,6 +12,9 @@ import dask_gateway
 
 logger = logging.getLogger("DaskWorkflow")
 
+def client_code():
+    pass
+
 def main():
     gw = dask_gateway.Gateway(auth="jupyterhub")
 
@@ -27,7 +30,7 @@ def main():
 
         logger.warning(f"Client dashboard: {client.dashboard_link}")
 
-        # Client code goes here
+        client_code()
     finally:
         gw.stop_cluster(client.cluster.name)
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -11,21 +11,26 @@ import logging
 import dask_gateway
 
 logger = logging.getLogger("DaskWorkflow")
-gw = dask_gateway.Gateway(auth="jupyterhub")
 
-try:
-    opts = gw.cluster_options()
-    opts.worker_memory = int(os.environ['DASK_OPTS__WORKER_MEMORY'])
-    opts.worker_cores = int(os.environ['DASK_OPTS__WORKER_CORES'])
-    opts.scheduler_memory = int(os.environ['DASK_OPTS__SCHEDULER_MEMORY'])
-    opts.scheduler_cores = int(os.environ['DASK_OPTS__SCHEDULER_CORES'])
-    cluster = gw.new_cluster(opts)
-    cluster.scale(int(os.environ['DASK_OPTS__N_WORKERS']))
-    client = cluster.get_client()
+def main():
+    gw = dask_gateway.Gateway(auth="jupyterhub")
 
-    logger.warning(f"Client dashboard: {client.dashboard_link}")
+    try:
+        opts = gw.cluster_options()
+        opts.worker_memory = int(os.environ['DASK_OPTS__WORKER_MEMORY'])
+        opts.worker_cores = int(os.environ['DASK_OPTS__WORKER_CORES'])
+        opts.scheduler_memory = int(os.environ['DASK_OPTS__SCHEDULER_MEMORY'])
+        opts.scheduler_cores = int(os.environ['DASK_OPTS__SCHEDULER_CORES'])
+        cluster = gw.new_cluster(opts)
+        cluster.scale(int(os.environ['DASK_OPTS__N_WORKERS']))
+        client = cluster.get_client()
 
-    # Client code goes here
-finally:
-    gw.stop_cluster(client.cluster.name)
+        logger.warning(f"Client dashboard: {client.dashboard_link}")
+
+        # Client code goes here
+    finally:
+        gw.stop_cluster(client.cluster.name)
+
+if __name__=="__main__":
+    main()
 ```

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,3 +1,31 @@
 # Argo Workflow Archive
 
 This directory contains a collection of `Workflow` definitions for Argo to do tasks that we may want to repeat.  As we learn Argo better, we might be able to make better use of these resources for more complex tasks.
+
+## Dask task runner
+The provided `run-dask-job.yaml` allows for the specification of an HTTP(S) URL to a Python script which will be downloaded and run in a Dask cluster that will be configured to the scale dictated by the other job parameters.
+
+Scripts that wish to use this framework should use the following as the starting point for their code:
+```python
+import logging
+import dask_gateway
+
+logger = logging.getLogger("DaskWorkflow")
+gw = dask_gateway.Gateway(auth="jupyterhub")
+
+try:
+    opts = gw.cluster_options()
+    opts.worker_memory = int(os.environ['DASK_OPTS__WORKER_MEMORY'])
+    opts.worker_cores = int(os.environ['DASK_OPTS__WORKER_CORES'])
+    opts.scheduler_memory = int(os.environ['DASK_OPTS__SCHEDULER_MEMORY'])
+    opts.scheduler_cores = int(os.environ['DASK_OPTS__SCHEDULER_CORES'])
+    cluster = gw.new_cluster(opts)
+    cluster.scale(int(os.environ['DASK_OPTS__N_WORKERS']))
+    client = cluster.get_client()
+
+    logger.warning(f"Client dashboard: {client.dashboard_link}")
+
+    # Client code goes here
+finally:
+    gw.stop_cluster(client.cluster.name)
+```

--- a/workflows/run-dask-job.yaml
+++ b/workflows/run-dask-job.yaml
@@ -53,7 +53,7 @@ spec:
             value: gateway://traefik-dask-gateway:80
           - name: DASK_GATEWAY__PUBLIC_ADDRESS
             value: /services/dask-gateway
-          - name: DASK_GATEWAY__AUTH_TYPE
+          - name: DASK_GATEWAY__AUTH__TYPE
             value: jupyterhub
           - name: JUPYTERHUB_API_TOKEN
             valueFrom:

--- a/workflows/run-dask-job.yaml
+++ b/workflows/run-dask-job.yaml
@@ -61,15 +61,15 @@ spec:
                 name: auth-token
                 key: token
           - name: DASK_OPTS__WORKER_MEMORY
-            value: {{inputs.parameters.worker-mem-gb}}
+            value: "{{inputs.parameters.worker-mem-gb}}"
           - name: DASK_OPTS__WORKER_CORES
-            value: {{inputs.parameters.worker-cores}}
+            value: "{{inputs.parameters.worker-cores}}"
           - name: DASK_OPTS__N_WORKERS
-            value: {{inputs.parameters.n-workers}}
+            value: "{{inputs.parameters.n-workers}}"
           - name: DASK_OPTS__SCHEDULER_MEMORY
-            value: {{inputs.parameters.scheduler-mem-gb}}
+            value: "{{inputs.parameters.scheduler-mem-gb}}"
           - name: DASK_OPTS__SCHEDULER_CORES
-            value: {{inputs.parameters.scheduler-cores}}
+            value: "{{inputs.parameters.scheduler-cores}}"
         volumeMounts:
           - name: scratch
             mountPath: /scratch

--- a/workflows/run-dask-job.yaml
+++ b/workflows/run-dask-job.yaml
@@ -3,9 +3,19 @@ apiVersion: argoproj.io/v1alpha1
 #kind: ClusterWorkflowTemplate
 kind: Workflow
 metadata:
-  name: dask-distributed-task-workflow
+  generateName: dask-distributed-task-workflow-
 spec:
   entrypoint: execute-dask-job
+  securityContext:
+    fsGroup: 1000
+  volumeClaimTemplates:
+    - metadata:
+        name: scratch
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 128Gi
   arguments:
     parameters:
       - name: script-location
@@ -13,15 +23,14 @@ spec:
         value: "pangeo/pangeo-notebook:2022.05.18"
       - name: n-workers
         value: "1"
-      - name: worker-mcpu
-        value: "500"
+      - name: worker-cores
+        value: "1"
       - name: worker-mem-gb
         value: "2"
-      - name: scheduler-mcpu
-        value: "1000"
+      - name: scheduler-cores
+        value: "1"
       - name: scheduler-mem-gb
         value: "4"
-
   templates:
     - name: execute-dask-job
       inputs:
@@ -29,9 +38,9 @@ spec:
           - name: script-location
           - name: image
           - name: n-workers
-          - name: worker-mcpu
+          - name: worker-cores
           - name: worker-mem-gb
-          - name: scheduler-mcpu
+          - name: scheduler-cores
           - name: scheduler-mem-gb
       script:
         image: "{{inputs.parameters.image}}"
@@ -43,16 +52,30 @@ spec:
           - name: DASK_GATEWAY__PROXY_ADDRESS
             value: gateway://traefik-dask-gateway:80
           - name: DASK_GATEWAY__PUBLIC_ADDRESS
-            value: /sercices/dask-gateway
+            value: /services/dask-gateway
+          - name: DASK_GATEWAY__AUTH_TYPE
+            value: jupyterhub
           - name: JUPYTERHUB_API_TOKEN
             valueFrom:
               secretKeyRef:
                 name: auth-token
                 key: token
+          - name: DASK_OPTS__WORKER_MEMORY
+            value: {{inputs.parameters.worker-mem-gb}}
+          - name: DASK_OPTS__WORKER_CORES
+            value: {{inputs.parameters.worker-cores}}
+          - name: DASK_OPTS__N_WORKERS
+            value: {{inputs.parameters.n-workers}}
+          - name: DASK_OPTS__SCHEDULER_MEMORY
+            value: {{inputs.parameters.scheduler-mem-gb}}
+          - name: DASK_OPTS__SCHEDULER_CORES
+            value: {{inputs.parameters.scheduler-cores}}
+        volumeMounts:
+          - name: scratch
+            mountPath: /scratch
+        workingDir: "/scratch"
         source: |
           pwd
           export
-          SCRIPT_URL={{inputs.parameter.script-location}}
-          SCRIPT_NAME=$(basename $SCRIPT_URL)
-          wget -q -o source.py $SCRIPT_URL
+          wget -q --output-document=source.py "{{inputs.parameters.script-location}}"
           python source.py

--- a/workflows/run-dask-job.yaml
+++ b/workflows/run-dask-job.yaml
@@ -1,0 +1,58 @@
+# inspired by https://raw.githubusercontent.com/pipekit/talk-demos/main/argocon-demos/2021-processing-petabytes-with-dask/dask_standard_cluster_workflow_template.yaml
+apiVersion: argoproj.io/v1alpha1
+#kind: ClusterWorkflowTemplate
+kind: Workflow
+metadata:
+  name: dask-distributed-task-workflow
+spec:
+  entrypoint: execute-dask-job
+  arguments:
+    parameters:
+      - name: script-location
+      - name: image
+        value: "pangeo/pangeo-notebook:2022.05.18"
+      - name: n-workers
+        value: "1"
+      - name: worker-mcpu
+        value: "500"
+      - name: worker-mem-gb
+        value: "2"
+      - name: scheduler-mcpu
+        value: "1000"
+      - name: scheduler-mem-gb
+        value: "4"
+
+  templates:
+    - name: execute-dask-job
+      inputs:
+        parameters:
+          - name: script-location
+          - name: image
+          - name: n-workers
+          - name: worker-mcpu
+          - name: worker-mem-gb
+          - name: scheduler-mcpu
+          - name: scheduler-mem-gb
+      script:
+        image: "{{inputs.parameters.image}}"
+        imagePullPolicy: Always
+        command: [bash]
+        env:
+          - name: DASK_GATEWAY__ADDRESS
+            value: http://traefik-dask-gateway/services/dask-gateway
+          - name: DASK_GATEWAY__PROXY_ADDRESS
+            value: gateway://traefik-dask-gateway:80
+          - name: DASK_GATEWAY__PUBLIC_ADDRESS
+            value: /sercices/dask-gateway
+          - name: JUPYTERHUB_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: auth-token
+                key: token
+        source: |
+          pwd
+          export
+          SCRIPT_URL={{inputs.parameter.script-location}}
+          SCRIPT_NAME=$(basename $SCRIPT_URL)
+          wget -q -o source.py $SCRIPT_URL
+          python source.py


### PR DESCRIPTION
## Overview

This PR provides some infrastructure for running Dask jobs independent of Jupyter.  This enables long-running jobs that would be cumbersome to remain logged into Jupyter for.  It also opens up a workflow based on standard python scripts, rather than Jupyter notebooks.  I've been using a standard form for my scripts so that the cluster can be configured via the Argo job submission interface:

```python
import logging
import dask_gateway

logger = logging.getLogger("DaskWorkflow")
gw = dask_gateway.Gateway(auth="jupyterhub")

try:
    opts = gw.cluster_options()
    opts.worker_memory = int(os.environ['DASK_OPTS__WORKER_MEMORY'])
    opts.worker_cores = int(os.environ['DASK_OPTS__WORKER_CORES'])
    opts.scheduler_memory = int(os.environ['DASK_OPTS__SCHEDULER_MEMORY'])
    opts.scheduler_cores = int(os.environ['DASK_OPTS__SCHEDULER_CORES'])
    cluster = gw.new_cluster(opts)
    cluster.scale(int(os.environ['DASK_OPTS__N_WORKERS']))
    client = cluster.get_client()

    logger.warning(f"Client dashboard: {client.dashboard_link}")

    # Client code goes here
finally:
    gw.stop_cluster(client.cluster.name)
```

Closes #112 

### Checklist

- [x] ~~Ran `nbautoexport export .` in `/opt/src/notebooks` and committed the generated scripts. This is to make reviewing notebooks easier. (Note the export will happen automatically after saving notebooks from the Jupyter web app.)~~
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes 

This workflow will eventually be added to the cluster configs as a `ClusterWorkflowTemplate`, but that will be handled by  azavea/kubernetes-deployment#34.

## Testing Instructions

- Start a new workflow
- Copy in the contents of `run-dask-job.yaml` into the manual editor
- Adjust the parameter values in the parameters tab to configure the size of the cluster and the source code location (currently the latter must be specified as an HTTP(S) URL)
- Run the workflow (there will be a 3–6 minute delay for the Dask resources to come on line)
- If you'd like to monitor the progress, grab the client dashboard URL from the pod logs for the task; append the value to `https://jupyter.noaa.azavea.com`
- Since the workflow does not specify any garbage collection, delete the workflow when you're done to avoid stacking up old pods
