### PR TITLE
Workflow to rechunk NWM retrospective zarr data

### DIFF
--- a/src/python-scripts/rechunk-retro-data.py
+++ b/src/python-scripts/rechunk-retro-data.py
@@ -1,0 +1,81 @@
+import logging
+from os.path import basename, join
+import os
+import shutil
+from os import makedirs
+
+import dask
+import dask_gateway
+import xarray as xr
+import fsspec
+from rechunker import rechunk
+import zarr
+
+
+logger = logging.getLogger("RechunkWorkflow")
+
+def remove_chunks_encoding(ds):
+    for var in list(ds.keys()) + list(ds.coords):
+        if 'chunks' in ds[var].encoding:
+            del ds[var].encoding['chunks']
+    return ds
+
+
+def _rechunk(src_ds, target_chunks, output_uri, tmp_uri):
+    # Putting in a safety factor for memory use; see https://github.com/pangeo-data/rechunker/issues/100#issue-1015598253
+    max_mem = f"{int(os.environ['DASK_OPTS__WORKER_MEMORY']) * 3 // 4}GB"
+    logger.warning(f"Setting max_mem to {max_mem}")
+
+    # Note, if you get a ContainsArrayError, you probably need to delete temp_store and target_store first.
+    # See https://github.com/pangeo-data/rechunker/issues/78
+
+    targ_store = fsspec.get_mapper(output_uri)
+    temp_store = fsspec.get_mapper(tmp_uri)
+    rechunk_plan = rechunk(src_ds, target_chunks, max_mem, targ_store, temp_store=temp_store)
+    rechunk_plan.execute()
+
+def client_code():
+    src_uri = 's3://noaa-nwm-retrospective-2-1-zarr-pds/chrtout.zarr'
+    with dask.config.set(**{'array.slicing.split_large_chunks': True}):
+        nwm_uri = 's3://noaa-nwm-retrospective-2-1-zarr-pds/chrtout.zarr'
+        ds = remove_chunks_encoding(
+            xr.open_zarr(src_uri).chunk({'time': 672, 'feature_id': 30000})
+        )
+        target_chunks = {'time': 30000, 'feature_id': 672}
+        _rechunk(
+            ds,
+            target_chunks,
+            's3://azavea-noaa-hydro-data/experiments/jp/rechunk/output.zarr',
+            tmp_uri='s3://azavea-noaa-hydro-data/experiments/jp/rechunk/tmp.zarr'
+        )
+        zarr.convenience.consolidate_metadata(
+            's3://azavea-noaa-hydro-data/experiments/jp/rechunk/output.zarr'
+        )
+
+
+def main():
+    gw = dask_gateway.Gateway()
+    cluster_name = None
+    logger.warning(f"Using auth type {type(gw.auth)}")
+
+    try:
+        opts = gw.cluster_options()
+        opts.worker_memory = int(os.environ['DASK_OPTS__WORKER_MEMORY'])
+        opts.worker_cores = int(os.environ['DASK_OPTS__WORKER_CORES'])
+        opts.scheduler_memory = int(os.environ['DASK_OPTS__SCHEDULER_MEMORY'])
+        opts.scheduler_cores = int(os.environ['DASK_OPTS__SCHEDULER_CORES'])
+        cluster = gw.new_cluster(opts)
+        cluster.scale(int(os.environ['DASK_OPTS__N_WORKERS']))
+        client = cluster.get_client()
+        cluster_name = cluster.name
+
+        logger.warning(f"Client dashboard: {client.dashboard_link}")
+
+        client_code()
+    finally:
+        if cluster_name is not None:
+            gw.stop_cluster(cluster_name)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Overview

We have wanted to rechunk the NWM retrospective data to be optimized for time-series queries over a limited spatial extent, which seems to be a more common use case.  Previous studies done by Azavea have shown that this style of query is faster on a rechunked data set.

When we run this process on a single EC2 node, we run out of memory for the job.  This PR presents a solution based on a Dask cluster running in Kubernetes.  Using an Argo workflow, we are able to execute the included python script (`rechunk-retro-data.py`) on an arbitrarily-sized cluster to perform the rechunking operation.  In my test, I used 48 workers with 8GB of RAM.  The result can be found at `s3://azavea-noaa-hydro-data/experiments/jp/rechunk/output.zarr`.

Closes #119 

### Checklist
- [x] ~~Ran `nbautoexport export .` in `/opt/src/notebooks` and committed the generated scripts. This is to make reviewing notebooks easier. (Note the export will happen automatically after saving notebooks from the Jupyter web app.)~~
- [ ] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes
~~This is built on top of the contents of #120.  This PR should be considered a draft until that PR is merged.~~  Rebased and ready.

## Testing Instructions
- Start a workflow based on the `run-dask-job.yaml` workflow template
- Point the `script-location` parameter to a version of `rechunk-retro-data.py` that sets the proper output URI location (figuring out a clean way to pass arguments via the Argo UI is a task for the future)
- Tune the scale of your cluster
- Create the workflow
- Monitor the logs for the Dask client dashboard, append it to https://jupyter.noaa.azavea.com, and direct a browser to that URL to watch the job progress