### PR TITLE
Templates for workflows consuming EFS-backed volumes

### DIFF
--- a/workflows/read-from-volume.yaml
+++ b/workflows/read-from-volume.yaml
@@ -1,0 +1,20 @@
+metadata:
+  generateName: read-from-volume-
+  namespace: daskhub
+spec:
+  entrypoint: tree
+  volumes:
+  - name: noaa-ro
+    persistentVolumeClaim:
+      claimName: noaa-hydro-data
+      readOnly: true
+  templates:
+    - name: tree
+      container:
+        name: main
+        image: iankoulski/tree
+        args:
+          - /opt/data
+        volumeMounts:
+        - name: noaa-ro
+          mountPath: /opt/data

--- a/workflows/transfer-to-volume.yaml
+++ b/workflows/transfer-to-volume.yaml
@@ -1,0 +1,38 @@
+metadata:
+  generateName: transfer-to-volume-
+  namespace: daskhub
+spec:
+  arguments:
+    parameters:
+      - name: command
+        value: sync
+      - name: source-s3-uri
+      - name: dest-path
+        value: /opt/data
+  entrypoint: s3-command
+  volumes:
+  - name: noaa
+    persistentVolumeClaim:
+      claimName: noaa-hydro-data
+      readOnly: false
+  templates:
+    - name: s3-command
+      inputs:
+        parameters:
+          - name: src
+            value: '{{workflow.parameters.source-s3-uri}}'
+          - name: dest
+            value: '{{workflow.parameters.dest-path}}'
+          - name: cmd
+            value: '{{workflow.parameters.command}}'
+      container:
+        name: main
+        image: amazon/aws-cli
+        args:
+          - s3
+          - '{{inputs.parameters.cmd}}'
+          - '{{inputs.parameters.src}}'
+          - '{{inputs.parameters.dest}}'
+        volumeMounts:
+        - name: noaa
+          mountPath: /opt/data


### PR DESCRIPTION
## Overview

This PR provides some sample Argo workflow templates that use EFS-backed volumes to share data among pods.  The volumes provided are furnished by the infrastructure in azavea/kubernetes-deployment#38, which must be merged prior to accepting this PR.

### Checklist

- [x] ~~Ran `nbautoexport export .` in `/opt/src/notebooks` and committed the generated scripts. This is to make reviewing notebooks easier. (Note the export will happen automatically after saving notebooks from the Jupyter web app.)~~
- [ ] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

## Testing Instructions

* Create a workflow from the Argo dashboard
* Copy in the contents of either YAML file provided by this PR
* Supply parameter values if required
* Run workflow
* Profit

